### PR TITLE
Don't add modal markup unless adding/editing a post

### DIFF
--- a/lib/CodeSnippitButton.php
+++ b/lib/CodeSnippitButton.php
@@ -48,6 +48,13 @@ class CodeSnippitButton {
 	}
 
 	public function quicktag_button_script() {
+		global $pagenow;
+		
+		// bail early if not adding/editing a post
+		if ( ! ( 'post-new.php' === $pagenow ) && ! ( 'post.php' === $pagenow ) ) {
+			return;
+		}
+		
 		wp_enqueue_style( 'wp-jquery-ui-dialog' );
 		wp_enqueue_script( $this->script );
 


### PR DESCRIPTION
This avoids the following error on the main dashboard page:

[06-May-2016 13:13:33 UTC] PHP Fatal error:  Call to undefined function post_categories_meta_box() in /srv/www/pluginize/htdocs/wp-content/plugins/Code-Snippets-CPT-pr_1/lib/CodeSnippitButton.php on line 248